### PR TITLE
fixing a bug i introduced

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -176,9 +176,8 @@ def sim_gwas(L, ngwas, b_qtls, var_explained):
 
     gwas = regress(Z_gwas, y)
 
-    # correct gwas and alpha for original SD of y
+    # correct alpha for original SD of y
     alpha /= y_std
-    gwas /= y_std
 
     return (gwas, alpha)
 


### PR DESCRIPTION
Apologies, this line where I modified `gwas` was mistaken. I was looking at some of the output, and the GWAS betas should _not_ be corrected with the original SD of y. With this second PR, regressing true GWAS on true eQTL gives the `alpha` and using estimated quantities gets you close as well. I looked across a couple of sims (whereas last time I hadn't checked the estimated GWAS beta that were being output).

Once `alpha` has been corrected as in the previous PR, then the correct output is the estimated GWAS betas of the _unit-scaled y_ (as it was before), and during the output of the true GWAS betas, since `alpha` has been corrected, no code change is needed.